### PR TITLE
FROST repair: don't point to curve.Scalar

### DIFF
--- a/protocols/frost/frost.go
+++ b/protocols/frost/frost.go
@@ -84,7 +84,7 @@ func RefreshTaproot(config *TaprootConfig, participants []party.ID) protocol.Sta
 }
 
 // Repair initiates the protocol for repairing a lost key.
-func Repair(helpers []party.ID, lostID, selfID party.ID, privateShare *curve.Scalar) protocol.StartFunc {
+func Repair(helpers []party.ID, lostID, selfID party.ID, privateShare curve.Scalar) protocol.StartFunc {
 	return repair.Repair(helpers, lostID, selfID, privateShare)
 }
 

--- a/protocols/frost/frost_test.go
+++ b/protocols/frost/frost_test.go
@@ -113,7 +113,7 @@ func doRefreshOnly(t *testing.T, c Config, ids []party.ID, n *test.Network) Conf
 	return *r.(*Config)
 }
 
-func doRepairOnly(t *testing.T, helpers []party.ID, lostID, selfID party.ID, privateShare *curve.Scalar, n *test.Network) curve.Scalar {
+func doRepairOnly(t *testing.T, helpers []party.ID, lostID, selfID party.ID, privateShare curve.Scalar, n *test.Network) curve.Scalar {
 	h, err := protocol.NewMultiHandler(Repair(helpers, lostID, selfID, privateShare), nil)
 	require.NoErrorf(t, err, "error in Repair for %s", selfID)
 	test.HandlerLoop(selfID, h, n)
@@ -340,10 +340,10 @@ func TestFrostRepair(t *testing.T) {
 	wg.Add(len(participants))
 	var repairedShare curve.Scalar
 	for _, id := range participants {
-		var privateShare *curve.Scalar
+		var privateShare curve.Scalar
 		if id != lostID {
 			c := configs[id]
-			privateShare = &c.PrivateShare
+			privateShare = c.PrivateShare
 		}
 		go func() {
 			defer wg.Done()

--- a/protocols/frost/repair/repair.go
+++ b/protocols/frost/repair/repair.go
@@ -25,7 +25,7 @@ var (
 	_ round.Round = (*round3)(nil)
 )
 
-func Repair(helpers []party.ID, lostID, selfID party.ID, privateShare *curve.Scalar) protocol.StartFunc {
+func Repair(helpers []party.ID, lostID, selfID party.ID, privateShare curve.Scalar) protocol.StartFunc {
 	return func(sessionID []byte) (round.Session, error) {
 		if len(helpers) < 2 {
 			return nil, fmt.Errorf(

--- a/protocols/frost/repair/round1.go
+++ b/protocols/frost/repair/round1.go
@@ -19,7 +19,7 @@ type round1 struct {
 	lostID party.ID
 	// privateShare is the secret share of a helper
 	// This should be nil for the lost share.
-	privateShare *curve.Scalar
+	privateShare curve.Scalar
 }
 
 // VerifyMessage implements round.Round.
@@ -67,7 +67,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	}
 
 	zeta := computeLagrangeCoefficient(group, r.helpers, r.lostID, r.SelfID())
-	lhs := group.NewScalar().Set(zeta).Mul(*r.privateShare)
+	lhs := group.NewScalar().Set(zeta).Mul(r.privateShare)
 	deltaSum := group.NewScalar()
 	for i := range len(r.helpers) - 1 {
 		id := r.helpers[i]


### PR DESCRIPTION
curve.Scalar is, as an interface type, already a pointer. This library never points to it. We should follow that pattern.