### PR TITLE
FROST repair: handle zero share

### DIFF
--- a/protocols/frost/frost_test.go
+++ b/protocols/frost/frost_test.go
@@ -341,7 +341,9 @@ func TestFrostRepair(t *testing.T) {
 	var repairedShare curve.Scalar
 	for _, id := range participants {
 		var privateShare curve.Scalar
-		if id != lostID {
+		if id == lostID {
+			privateShare = &curve.Secp256k1Scalar{}
+		} else {
 			c := configs[id]
 			privateShare = c.PrivateShare
 		}

--- a/protocols/frost/repair/repair.go
+++ b/protocols/frost/repair/repair.go
@@ -31,18 +31,18 @@ func Repair(helpers []party.ID, lostID, selfID party.ID, privateShare curve.Scal
 			return nil, fmt.Errorf("repair.Repair: helpers must be non-empty")
 		}
 		if lostID == selfID {
-			if privateShare != nil {
+			if privateShare != nil && !privateShare.IsZero() {
 				return nil, fmt.Errorf(
-					"repair.Repair: private share should be nil for lost share")
+					"repair.Repair: private share should be nil or zero for lost share")
 			}
 			if slices.ContainsFunc(helpers, func(id party.ID) bool { return id == lostID }) {
 				return nil, fmt.Errorf(
 					"repair.Repair: lost share ID (%v) should not be in helpers (%v)", lostID, helpers)
 			}
 		} else {
-			if privateShare == nil {
+			if privateShare == nil || privateShare.IsZero() {
 				return nil, fmt.Errorf(
-					"repair.Repair: private share should not be nil for helper share")
+					"repair.Repair: private share should not be nil or zero for helper share")
 			}
 			if !slices.ContainsFunc(helpers, func(id party.ID) bool { return id == selfID }) {
 				return nil, fmt.Errorf(

--- a/protocols/frost/repair/round1.go
+++ b/protocols/frost/repair/round1.go
@@ -18,7 +18,7 @@ type round1 struct {
 	// lostID is the ID of the lost share.
 	lostID party.ID
 	// privateShare is the secret share of a helper
-	// This should be nil for the lost share.
+	// This should be nil or zero for the lost share.
 	privateShare curve.Scalar
 }
 
@@ -42,7 +42,7 @@ func (round1) Number() round.Number { return 1 }
 // Round 1 generates delta values from each helper to help the lost share reconstruct its secret.
 func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	dummyMsg := &message2{r.Group().NewScalar()}
-	if r.privateShare == nil {
+	if r.privateShare == nil || r.privateShare.IsZero() {
 		// The lost share does nothing until round 3.
 		// Library internals, however, require that each share send a message to the other shares
 		// before proceeding to round finalization, so we send a dummy message here.

--- a/protocols/frost/repair/round2.go
+++ b/protocols/frost/repair/round2.go
@@ -26,7 +26,7 @@ func (r *round2) VerifyMessage(msg round.Message) error {
 }
 
 func (r *round2) StoreMessage(msg round.Message) error {
-	if r.privateShare == nil {
+	if r.privateShare == nil || r.privateShare.IsZero() {
 		// lost share does nothing until round 3
 		return nil
 	}
@@ -53,7 +53,7 @@ func (*round2) Number() round.Number { return 2 }
 // `sigma` is the sum of all deltas.
 func (r *round2) Finalize(out chan<- *round.Message) (round.Session, error) {
 	dummyMsg := &message3{r.Group().NewScalar()}
-	if r.privateShare == nil {
+	if r.privateShare == nil || r.privateShare.IsZero() {
 		// The lost share does nothing until round 3.
 		// Library internals, however, require that each share send a message to the other shares
 		// before proceeding to round finalization, so we send a dummy message here.

--- a/protocols/frost/repair/round3.go
+++ b/protocols/frost/repair/round3.go
@@ -26,7 +26,7 @@ func (r *round3) VerifyMessage(msg round.Message) error {
 }
 
 func (r *round3) StoreMessage(msg round.Message) error {
-	if r.privateShare != nil {
+	if r.privateShare != nil && !r.privateShare.IsZero() {
 		// only the lost share does anything in round 3
 		return nil
 	}
@@ -47,7 +47,7 @@ func (*round3) Number() round.Number { return 3 }
 // Round 3 only involves the lost share:
 // It sums contributed sigmas to create a new secret share.
 func (r *round3) Finalize(chan<- *round.Message) (round.Session, error) {
-	if r.privateShare != nil {
+	if r.privateShare != nil && !r.privateShare.IsZero() {
 		// only the lost share needs to compute the secret
 		// we return zero scalar for consistency
 		return r.ResultRound(r.Group().NewScalar()), nil


### PR DESCRIPTION
FROST repair should correctly handle a zero-valued private share.